### PR TITLE
Change AllowSpeech to use SpeechTime instead

### DIFF
--- a/AdminToolbox/AdminToolbox/MyMiscEvents.cs
+++ b/AdminToolbox/AdminToolbox/MyMiscEvents.cs
@@ -60,7 +60,7 @@ namespace AdminToolbox
                 foreach (string item in blackListedSTEAMIDS)
                     if (item == ev.Player.SteamId)
                     {
-                        ev.AllowSpeech = false;
+                        ev.SpeechTime = 0;
                         break;
                     }
         }


### PR DESCRIPTION
Change AllowSpeech to use SpeechTime instead

This isn't a perfect fix but should still have the expected behaviour

This change is to make this plugin work with the latest update